### PR TITLE
Add GitHub Pull Request Template to config-files for inclusion in new repositories

### DIFF
--- a/config-files/.github/PULL_REQUEST_TEMPLATE.md
+++ b/config-files/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,8 @@
 ### PR Checklist
 
 - [ ] JIRA Ticket(s) included in PR Title and are formatted correctly if applicable (JIRA-123)
-- [ ] PR Title has a short summary of what changes are included
-- [ ] PR Description below includes additional detail that isn't included in the title summary
+- [ ] PR Title is a short summary of your changes
+- [ ] PR Description includes details not included in the title summary
 - [ ] Assign applicable leads to your PR for review
 
 ### Additional PR Detail

--- a/config-files/.github/PULL_REQUEST_TEMPLATE.md
+++ b/config-files/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,10 @@
+### PR Checklist
+
+- [ ] JIRA Ticket(s) included in PR Title and are formatted correctly if applicable (JIRA-123)
+- [ ] PR Title has a short summary of what changes are included
+- [ ] PR Description below includes additional detail that isn't included in the title summary
+- [ ] Assign applicable leads to your PR for review
+
+### Additional PR Detail
+_Please provide additional detail of changes here._
+

--- a/config-files/.github/PULL_REQUEST_TEMPLATE.md
+++ b/config-files/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,10 +1,9 @@
 ### PR Checklist
 
-- [ ] JIRA Ticket(s) included in PR Title and are formatted correctly if applicable (JIRA-123)
+- [ ] Applicable JIRA Ticket(s) included in the PR Title and formatted correctly: JIRA-123
 - [ ] PR Title is a short summary of your changes
 - [ ] PR Description includes details not included in the title summary
 - [ ] Assign applicable leads to your PR for review
 
-### Additional PR Detail
-_Please provide additional detail of changes here._
+### Additional PR Details Below:
 


### PR DESCRIPTION
### PR Checklist
- [X] PR Title has a short summary of what changes are included
- [x] PR Description below includes additional detail that isn't included in the title summary
- [X] Assign applicable leads to your PR for review

### Additional PR Detail
When the PULL_REQUEST_TEMPLATE.md file is added to either a repository root or `.github/PULL_REQUEST_TEMPLATE.md`
GitHub will automatically populate new pull requests with the template [as described in their documentation](https://help.github.com/articles/creating-a-pull-request-template-for-your-repository/).

Additionally each checkbox checked / total will appear in the PR list showing Checked / Unchecked. Inapplicable checkboxes can be removed per pull request so
commentary on adding `(Remove if inapplicable)` to the JIRA ticket line for things like hotfixes or dependency updates might be useful.